### PR TITLE
Add SQL and NoSQL injection training labs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,20 @@
-# tranchulas-sql-injection
-This is an SQL injection lab.
+# SQL and NoSQL Injection Labs
+
+This repository contains a simple web application that demonstrates two common vulnerabilities:
+
+- **Time-based blind SQL injection** using a vulnerable employee lookup page backed by SQLite.
+- **NoSQL injection** via a login form that unsafely parses user supplied JSON.
+
+The application is implemented in pure Python so it can run without extra dependencies.
+
+## Usage
+
+Start the server:
+
+```bash
+python3 app.py
+```
+
+Then open `http://localhost:8000` in your browser. You will see links to both labs.
+
+These labs are intentionally vulnerable and should only be used in a controlled environment for educational purposes.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,139 @@
+import sqlite3
+import time
+import os
+from urllib.parse import parse_qs
+from wsgiref.simple_server import make_server
+import json
+
+DB_PATH = os.path.join(os.path.dirname(__file__), 'org.db')
+
+EMPLOYEES = [
+    (1, 'Alice Johnson', 'CEO', 'Management'),
+    (2, 'Bob Smith', 'CTO', 'Technology'),
+    (3, 'Carol White', 'CFO', 'Finance'),
+    (4, 'Dave Brown', 'HR Manager', 'Human Resources')
+]
+
+USERS = [
+    {'username': 'alice', 'password': 'password1', 'name': 'Alice Johnson'},
+    {'username': 'bob', 'password': 'password2', 'name': 'Bob Smith'}
+]
+
+# setup database
+if not os.path.exists(DB_PATH):
+    conn = sqlite3.connect(DB_PATH)
+    c = conn.cursor()
+    c.execute('CREATE TABLE employees (id INTEGER PRIMARY KEY, name TEXT, role TEXT, department TEXT)')
+    c.executemany('INSERT INTO employees VALUES (?, ?, ?, ?)', EMPLOYEES)
+    conn.commit()
+    conn.close()
+
+# helper to load templates
+def render_template(name, **context):
+    path = os.path.join('templates', name)
+    with open(path, 'r') as f:
+        content = f.read()
+    for k, v in context.items():
+        content = content.replace('{' + k + '}', str(v))
+    return content.encode()
+
+def application(environ, start_response):
+    path = environ.get('PATH_INFO', '/')
+    if path.startswith('/static/'):
+        return serve_static(environ, start_response, path)
+    if path == '/sql-lab':
+        return sql_lab(environ, start_response)
+    if path == '/nosql-lab':
+        return nosql_lab(environ, start_response)
+    else:
+        start_response('200 OK', [('Content-Type', 'text/html')])
+        return [render_template('index.html')]
+
+def serve_static(environ, start_response, path):
+    filepath = path.lstrip('/')
+    if not os.path.exists(filepath):
+        start_response('404 Not Found', [('Content-Type', 'text/plain')])
+        return [b'Not found']
+    with open(filepath, 'rb') as f:
+        data = f.read()
+    start_response('200 OK', [('Content-Type', 'text/css')])
+    return [data]
+
+def sql_lab(environ, start_response):
+    qs = parse_qs(environ.get('QUERY_STRING', ''))
+    id_value = qs.get('id', [''])[0]
+    result_html = ''
+    if id_value:
+        conn = sqlite3.connect(DB_PATH)
+        def sleep(x):
+            time.sleep(float(x))
+            return 0
+        conn.create_function('sleep', 1, sleep)
+        c = conn.cursor()
+        query = f"SELECT id, name, role, department FROM employees WHERE id = {id_value}"
+        try:
+            rows = c.execute(query).fetchall()
+            if rows:
+                result_html = '<ul>' + ''.join(f'<li>{row[1]} - {row[2]} ({row[3]})</li>' for row in rows) + '</ul>'
+            else:
+                result_html = '<p>No employee found.</p>'
+        except sqlite3.Error as e:
+            result_html = f'<p>Error: {e}</p>'
+        conn.close()
+    start_response('200 OK', [('Content-Type', 'text/html')])
+    return [render_template('sql_lab.html', id=id_value, result=result_html)]
+
+def nosql_lab(environ, start_response):
+    if environ['REQUEST_METHOD'] == 'POST':
+        length = int(environ.get('CONTENT_LENGTH', '0'))
+        body = environ['wsgi.input'].read(length).decode()
+        params = parse_qs(body)
+        username_raw = params.get('username', [''])[0]
+        password_raw = params.get('password', [''])[0]
+        try:
+            username = json.loads(username_raw)
+        except json.JSONDecodeError:
+            username = username_raw
+        try:
+            password = json.loads(password_raw)
+        except json.JSONDecodeError:
+            password = password_raw
+        query = {'username': username, 'password': password}
+        user = find_user(query)
+        if user:
+            result_html = f'<p>Welcome {user["name"]}!</p>'
+        else:
+            result_html = '<p>Invalid credentials.</p>'
+        start_response('200 OK', [('Content-Type', 'text/html')])
+        return [render_template('nosql_lab.html', username=username_raw, password=password_raw, result=result_html)]
+    else:
+        start_response('200 OK', [('Content-Type', 'text/html')])
+        return [render_template('nosql_lab.html', username='', password='', result='')]
+
+def match_condition(value, condition):
+    if isinstance(condition, dict):
+        if '$ne' in condition:
+            return value != condition['$ne']
+        if '$eq' in condition:
+            return value == condition['$eq']
+        return False
+    else:
+        return value == condition
+
+def find_user(query):
+    for user in USERS:
+        match = True
+        for k, v in query.items():
+            if k not in user or not match_condition(user[k], v):
+                match = False
+                break
+        if match:
+            return user
+    return None
+
+if __name__ == '__main__':
+    import sys
+    port = int(sys.argv[1]) if len(sys.argv) > 1 else 8000
+    with make_server('', port, application) as httpd:
+        print(f'Serving on port {port}...')
+        httpd.serve_forever()

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,25 @@
+body {
+    font-family: Arial, sans-serif;
+    background-color: #f4f4f4;
+    color: #333;
+    margin: 0;
+    padding: 0;
+}
+header {
+    background-color: #eaeaea;
+    padding: 20px;
+    text-align: center;
+}
+main {
+    padding: 20px;
+}
+form {
+    margin: 20px 0;
+}
+input[type="text"], input[type="password"] {
+    padding: 5px;
+    width: 200px;
+}
+input[type="submit"] {
+    padding: 5px 10px;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Vulnerable Labs</title>
+    <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+<header>
+    <h1>Acme Organization Labs</h1>
+</header>
+<main>
+    <p>Welcome to the training labs.</p>
+    <ul>
+        <li><a href="/sql-lab">Time-based Blind SQL Injection Lab</a></li>
+        <li><a href="/nosql-lab">NoSQL Injection Lab</a></li>
+    </ul>
+</main>
+</body>
+</html>

--- a/templates/nosql_lab.html
+++ b/templates/nosql_lab.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>NoSQL Injection Lab</title>
+    <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+<header>
+    <h1>User Login</h1>
+    <p>Demonstration of NoSQL injection vulnerability.</p>
+</header>
+<main>
+    <form method="post" action="/nosql-lab">
+        <input type="text" name="username" placeholder="Username" value="{username}">
+        <input type="password" name="password" placeholder="Password" value="{password}">
+        <input type="submit" value="Login">
+    </form>
+    {result}
+    <p><a href="/">Back to Home</a></p>
+</main>
+</body>
+</html>

--- a/templates/sql_lab.html
+++ b/templates/sql_lab.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>SQL Injection Lab</title>
+    <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+<header>
+    <h1>Employee Lookup</h1>
+    <p>Search employee records by ID.</p>
+</header>
+<main>
+    <form method="get" action="/sql-lab">
+        <input type="text" name="id" placeholder="Employee ID" value="{id}">
+        <input type="submit" value="Search">
+    </form>
+    {result}
+    <p><a href="/">Back to Home</a></p>
+</main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- build small Python web server with SQL and NoSQL injection vulnerabilities
- add minimal HTML templates and light theme styling
- document how to run the server

## Testing
- `python3 app.py 8002` *(fails: OSError: [Errno 98] Address already in use)*

------
https://chatgpt.com/codex/tasks/task_b_68514e5eb1808333b05dcf082e65dddb